### PR TITLE
Fix build warnings on MinGW and add CMake install commands.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,29 @@ if (UNIX AND NOT APPLE AND DEBUG)
 	add_definitions(-DDEBUG)
 endif()
 
+if (MINGW)
+	include(CheckCXXSourceCompiles)
+
+	set(CHECK_FILE_ALLOCATED_RANGE_BUFFER_STRUCT_DEFINED
+"
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <winioctl.h>
+
+int main()
+{
+	_FILE_ALLOCATED_RANGE_BUFFER alloc_buf;
+	return 0;
+}")
+
+	check_cxx_source_compiles("${CHECK_FILE_ALLOCATED_RANGE_BUFFER_STRUCT_DEFINED}"
+		HAVE_FILE_ALLOCATED_RANGE_BUFFER)
+
+	if (HAVE_FILE_ALLOCATED_RANGE_BUFFER)
+		add_definitions(-DHAVE_FILE_ALLOCATED_RANGE_BUFFER)
+	endif()
+endif()
+
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories(include)
 
@@ -49,3 +72,6 @@ endif()
 
 target_link_libraries(avhttp libavhttp)
 target_link_libraries(form libavhttp)
+
+install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY example/ DESTINATION share/avhttp/examples)

--- a/include/avhttp/detail/parsers.hpp
+++ b/include/avhttp/detail/parsers.hpp
@@ -53,7 +53,10 @@ namespace detail {
 #endif
 
 #if defined(_WIN32)
-#	define strcasecmp lstrcmpiA
+#  if defined(strcasecmp)
+#    undef strcasecmp
+#  endif
+#  define strcasecmp lstrcmpiA
 #endif
 
 inline bool headers_equal(const std::string& a, const std::string& b)

--- a/include/avhttp/impl/file.ipp
+++ b/include/avhttp/impl/file.ipp
@@ -1178,11 +1178,15 @@ file::size_type file::sparse_end(size_type start) const
 {
 #ifdef WIN32
 #if defined(__MINGW32__) || defined(MINGW32)
+#ifndef HAVE_FILE_ALLOCATED_RANGE_BUFFER
 	typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 		LARGE_INTEGER FileOffset;
 		LARGE_INTEGER Length;
 	} FILE_ALLOCATED_RANGE_BUFFER, *PFILE_ALLOCATED_RANGE_BUFFER;
+#endif
+#ifndef FSCTL_QUERY_ALLOCATED_RANGES
 #define FSCTL_QUERY_ALLOCATED_RANGES ((0x9 << 16) | (1 << 14) | (51 << 2) | 3)
+#endif
 #endif
 	FILE_ALLOCATED_RANGE_BUFFER buffer;
 	DWORD bytes_returned = 0;


### PR DESCRIPTION
I fixed an annoying compile warning issue on MinGW builds due to the redefinition of the FILE_ALLOCATED_RANGE_BUFFER structure which is defined in more recent versions of MinGW.  I also added CMake install commands to install the headers in ${CMAKE_INSTALL_PREFIX}/include and the example files in ${CMAKE_INSTALL_PREFIX}/share/avhttp/examples.